### PR TITLE
.env의 port는 동작하지 않음

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
             # POSTGRES_USER: ${POSTGRES_USERNAME}
             # POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
             # POSTGRES_DB: ${POSTGRES_DATABASE}
-        ports:
-            - '${POSTGRES_PORT}:5432'
         networks:
             - default
 
@@ -20,8 +18,6 @@ services:
         image: redis:7.0-alpine
         profiles: ['infra']
         container_name: ${REDIS_HOST}
-        ports:
-            - ${REDIS_PORT}:6379
         networks:
             - default
 
@@ -29,8 +25,6 @@ services:
         image: mongo:7
         profiles: ['infra']
         container_name: ${MONGO_HOST}
-        ports:
-            - ${MONGO_PORT}:27017
         networks:
             - default
         environment:
@@ -51,8 +45,8 @@ services:
             ME_CONFIG_MONGODB_ENABLE_ADMIN: true
             ME_CONFIG_MONGODB_ADMINUSERNAME: ${MONGO_USERNAME}
             ME_CONFIG_MONGODB_ADMINPASSWORD: ${MONGO_PASSWORD}
-            ME_CONFIG_MONGODB_SERVER: mongo
-            ME_CONFIG_MONGODB_PORT: 27017
+            ME_CONFIG_MONGODB_SERVER: ${MONGO_HOST}
+            ME_CONFIG_MONGODB_PORT: ${MONGO_PORT}
 
     service:
         image: $PROJECT_NAME


### PR DESCRIPTION
컨테이너는 기본 포트만 사용한다.
.env.development는 기본 포트만 지정한다.
이번 문제는 컨테이너와 외부 접속 환경을 동시에 고려해서 생긴 문제다.
현재 환경에서 접속해야 하는 포트를 지정한다.
